### PR TITLE
Creating directories before file extact issue #8

### DIFF
--- a/src/android/decompressZip.java
+++ b/src/android/decompressZip.java
@@ -44,18 +44,26 @@ public class decompressZip {
     public boolean doUnZip(String actualTargetPath) throws IOException{
         File target = new File(actualTargetPath);
         if (!target.exists()) {
-            target.mkdir();
+            target.mkdirs();
         }
         
         ZipInputStream zipFl= new ZipInputStream(new FileInputStream(this.sourceEntry));
         ZipEntry entry      = zipFl.getNextEntry();
         
         while (entry != null) {
-            String filePath = actualTargetPath + File.separator + entry.getName();
+            String filePath = actualTargetPath + (actualTargetPath.endsWith("/") ? entry.getName() : File.separator + entry.getName());
             if (entry.isDirectory()) {
+                //This part doesn't seem to be fired
                 File path = new File(filePath);
                 path.mkdir();
             } else {
+                //That is why we check here if the target dir exists
+                File targetDir = new File(filePath.substring(0, filePath.lastIndexOf("/")));
+
+                if (!targetDir.exists()) {
+                    targetDir.mkdirs();
+                }
+                
                 extractFile(zipFl, filePath);
             }
             zipFl.closeEntry();


### PR DESCRIPTION
This allows unzipping in cacheDirectory (this might not be related but it's how I found the bug).

Apparently the original code in charge of creating the directories of extracted files does not work:

entry.isDirectory() never gets true

So I've added a few lines just to make sure the directory exists. Also changed mkdir() to mkdirs() to allow creation of deeper directories.