### PR TITLE
Fix 'cordova unable to install com.jjdltc.cordova.plugin.zip plugin' …

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Cordova zip compress and decompress",
   "cordova": {
-    "id": "com.jjdltc.cordova.plugin.zip",
+    "id": "cordova-zip-plugin",
     "platforms": [
       "android",
       "ios"

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@ See a full copy of license in the root folder of the project
 
 <plugin 
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
-    id="com.jjdltc.cordova.plugin.zip"
+    id="cordova-zip-plugin"
     version="2.0.0">
 
     <name>JJzip</name>


### PR DESCRIPTION
…after adding it to package.json->cordova->plugins list

When I do ```cordova plugin add cordova-zip-plugin``` it success but cordova insert ```com.jjdltc.cordova.plugin.zip``` to ```package.json->cordova->plugins``` When I delete platform directory and cordova is installing plugins it unable to find com.jjdltc.cordova.plugin.zip 😢 
And btw, thanks for huge time saving plugin 😄 