### PR TITLE
Additional API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,51 +17,52 @@ Installation
 Easy Use  
 ---  
   
-The object `JJzip` is expose in the `window`:
+The object `JJzip` is exposed in the `window`
 
-### Methonds
+## Operations
 
-* `zip(file [, options, successCallback, errorCallback])` - Allow to zip a file or folder (__Android only__)
-    * `file` - Path/To/File/Or/Folder
-    * `options` - Compression options in a JS object format (Key:"value")
-        * __target__: Path/To/Place/Result
-        * __name__: Name of the resulted zip (without the .zip)
-    * `successCallback` - Function to call in plugin success
-    * `errorCallback` - Function to call in plugin error
-* `unzip(file [, options, successCallback, errorCallback])` - Allow to unzip a zip file
-    * `file` - Path/To/File.zip (Expect a cordova style path file://)
-    * `options` - Extra options in a JS object format (Key:"value")
-        * __target__: Path/To/Place/Result
-    * `successCallback` - Function to call in plugin success
-    * `errorCallback` - Function to call in plugin error  
+### Zip Folder
 
-### Use Example  
+`zipFolder(folder, destination, successCallback, errorCallback])`
 
-To Zip a folder
-```
-    var PathToFileInString  = cordova.file.externalRootDirectory+"HereIsMyFolder",
-        PathToResultZip     = cordova.file.externalRootDirectory;
-    JJzip.zip(PathToFileInString, {target:PathToResultZip,name:"SuperZip"},function(data){
-        /* Wow everiting goes good, but just in case verify data.success*/
-    },function(error){
-        /* Wow something goes wrong, check the error.message */
-    })
-```  
+Creates a ZIP file with all the files in the given folder (recursive). Example: 
 
-Or To UnZip  
-
-```
-    var PathToFileInString  = cordova.file.externalRootDirectory+"HereIsMyFile.zip",
-        PathToResultZip     = cordova.file.externalRootDirectory;
-    JJzip.unzip(PathToFileInString, {target:PathToResultZip},function(data){
-        /* Wow everything goes good, but just in case verify data.success */
-    },function(error){
-        /* Wow something goes wrong, check the error.message */
-    })
+```javascript
+window.JJzip.zipFolder(
+    cordova.file.dataDirectory + 'inputFolder',
+    cordova.file.dataDirectory + 'out.zip',
+    function() { console.log('success'); },
+    function(err) { console.log('error: ' + err) });
 ```
 
-There is a big TODO list, but in resume  
-  
-* Write a better documentation
-* Add iOS Support (Partial support, only unzip)
-* Should handle some file manipulation (Like remove after zip the file?)
+### Zip Files
+
+`zipFolder(files, destination, successCallback, errorCallback])`
+
+Creates a flat ZIP file with all the given files. Example: 
+
+```javascript
+const files = [
+    cordova.file.dataDirectory + 'file1.txt',
+    cordova.file.dataDirectory + 'file2.txt',
+];
+window.JJzip.zipFiles(
+    files,
+    cordova.file.dataDirectory + 'out.zip',
+    function() { console.log('success'); },
+    function(err) { console.log('error: ' + err) });
+```
+
+### Unzip
+
+`unzip(zipFile, destination, successCallback, errorCallback])`
+
+Unzips the content of the given file in the destination folder. Example: 
+
+```javascript
+window.JJzip.unzip(
+    cordova.file.dataDirectory + 'input.zip',
+    cordova.file.dataDirectory + 'extracted',
+    function() { console.log('success'); },
+    function(err) { console.log('error: ' + err) });
+```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ window.JJzip.zipFolder(
 
 ### Zip Files
 
-`zipFolder(files, destination, successCallback, errorCallback])`
+`zipFiles(files, destination, successCallback, errorCallback])`
 
 Creates a flat ZIP file with all the given files. Example: 
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -50,7 +50,7 @@ See a full copy of license in the root folder of the project
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="SSZipArchive" spec="~> 2.1.4" />
+                <pod name="SSZipArchive" spec="~> 2.4.2" />
             </pods>
         </podspec>
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@ See a full copy of license in the root folder of the project
 
 <plugin 
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
-    id="com.jjdltc.cordova.plugin.zip"
+    id="cordova-zip-plugin"
     version="3.0.0">
 
     <name>JJzip</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,7 @@ See a full copy of license in the root folder of the project
 <plugin 
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="com.jjdltc.cordova.plugin.zip"
-    version="2.0.0">
+    version="3.0.0">
 
     <name>JJzip</name>
     <description>Cordova zip compress and decompress</description>
@@ -30,8 +30,8 @@ See a full copy of license in the root folder of the project
         </config-file>
 
         <source-file src="src/android/JJzip.java" target-dir="src/com/jjdltc/cordova/plugin/zip" />
-        <source-file src="src/android/compressZip.java" target-dir="src/com/jjdltc/cordova/plugin/zip" />
-        <source-file src="src/android/decompressZip.java" target-dir="src/com/jjdltc/cordova/plugin/zip" />
+        <source-file src="src/android/CompressZip.java" target-dir="src/com/jjdltc/cordova/plugin/zip" />
+        <source-file src="src/android/DecompressZip.java" target-dir="src/com/jjdltc/cordova/plugin/zip" />
     </platform>
 
     <platform name="ios">

--- a/src/android/JJzip.java
+++ b/src/android/JJzip.java
@@ -5,138 +5,104 @@
  */
 package com.jjdltc.cordova.plugin.zip;
 
+import android.net.Uri;
+import android.util.Log;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+
+import java.io.File;
 
 public class JJzip extends CordovaPlugin {
-
-    private enum ACTIONS {
-          zip
-        , unzip
-    };
+    private static final String TAG = "JJZip";
+    private final String ZIP_FILES = "zipFiles";
+    private final String ZIP_FOLDER = "zipFolder";
+    private final String UNZIP = "unzip";
     
-    /**
-     * Executes the request and returns PluginResult.
-     *
-     * @param action            The action to execute.
-     * @param args              JSONArry of arguments for the plugin.
-     * @param callbackContext   The callback id used when calling back into JavaScript.
-     * @return                  True if the action was valid, false if not.
-     */
-    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        boolean result          = true;
-        String actionType       = "";
-        JSONObject validOptions = validOptions(args);
-        
-        if(validOptions==null){
-            this.processResponse(callbackContext, false, "Some parameters were missed - Missed file path -");
-        }
-        
-        switch (ACTIONS.valueOf(action)) {
-            case zip:
-                actionType              = "compress";
-                compressZip makeZip     = new compressZip(validOptions);
-                result                  = makeZip.zip();
-            break;
-            case unzip:
-                actionType              = "decompress";
-                decompressZip unZip     = new decompressZip(validOptions);
-                result                  = unZip.unZip();
-            break;
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
+        switch (action) {
+            case ZIP_FILES:
+                zipFiles(args, callbackContext);
+                break;
+            case ZIP_FOLDER:
+                zipFolder(args, callbackContext);
+                break;
+            case UNZIP:
+                unzip(args, callbackContext);
+                break;
             default:
-                this.processResponse(callbackContext, false, "Some parameters were missed - Action not found -");
-                result = false;
-            break;
+                return false;
         }
 
-        String msg  = (result)?actionType+" Operation success":actionType+" Operation fail";
-        this.processResponse(callbackContext, result, msg);
-        return result;
+        return true;
     }
 
-    /**
-     * 
-     * @param ctx               The plugin CallbackContext
-     * @param success           boolean that define if the JS plugin should fire the success or error function
-     * @param msg               The String msg to by send
-     * @throws JSONException
-     */
-    private void processResponse(CallbackContext ctx, boolean success, String msg) throws JSONException{
-        JSONObject response = new JSONObject();
-        response.put("success", success);
-        response.put("message", msg);
-        if(success){
-            ctx.success(response);
-        }
-        else{
-            ctx.error(response);
+    private void zipFiles(final JSONArray args, final CallbackContext callbackContext) {
+        try {
+            final JSONArray fileUrls = args.getJSONArray(0);
+            final String targetPath = Uri.parse(args.getString(1)).getPath();
+
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                    try(final CompressZip zip = new CompressZip(targetPath)) {
+                        for (int i = 0; i < fileUrls.length(); i++) {
+                            zip.addFile(new File(Uri.parse(fileUrls.getString(i)).getPath()));
+                        }
+                    } catch (Exception e) {
+                        Log.e(TAG, "Unhandled exception compressing files: " + e);
+                        callbackContext.error(e.getMessage());
+                    }
+                    callbackContext.success();
+                }
+            });
+        } catch (Exception e) {
+            Log.e(TAG, "Unhandled exception parsing parameters: " + e);
+            callbackContext.error(e.getMessage());
         }
     }
-    
-    /**
-     * 
-     * @param args              The JSONArray sent by the client
-     * @return                  A Valid JSONObject with the need it options to execute or null if the file option path is not set
-     * @throws JSONException
-     */
-    private JSONObject validOptions(JSONArray args) throws JSONException{
-        
-        JSONObject options  = new JSONObject();
-        String source       = args.optString(0);
-        
-        if(source == null || source.isEmpty()){
-            return null;
+
+    private void zipFolder(final JSONArray args, final CallbackContext callbackContext) {
+        try {
+            final String folderPath = Uri.parse(args.getString(0)).getPath();
+            final String targetPath = Uri.parse(args.getString(1)).getPath();
+
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                    try(final CompressZip zip = new CompressZip(targetPath)) {
+                        zip.addDir(new File(folderPath));
+                    } catch (Exception e) {
+                        Log.e(TAG, "Unhandled exception compressing files: " + e);
+                        callbackContext.error(e.getMessage());
+                    }
+                    callbackContext.success();
+                }
+            });
+        } catch (Exception e) {
+            Log.e(TAG, "Unhandled exception parsing parameters: " + e);
+            callbackContext.error(e.getMessage());
         }
-        
-        options.put("source", source);
-        
-        JSONObject extraOptObj  = args.optJSONObject(1);
-        String[] extraOptArr    = new String[]{"target","name"};
-                
-        for (int i = 0; i < extraOptArr.length; i++) {
-            String strOpt   = extraOptObj.optString(extraOptArr[i]);
-            if(strOpt!=null && !strOpt.isEmpty()){
-                options.put(extraOptArr[i], strOpt);
-                options.put("useExtra", true);
-            }
-        }
-        options = validPaths(options);
-        
-        return options;
     }
-    
-    /**
-     * 
-     * @param options The passed options merges with the extra params
-     * @return A Valid JSONObject with the need it options to execute and the merge paths or null some of the paths are empty
-     * @throws JSONException
-     */
-    private JSONObject validPaths(JSONObject options) throws JSONException{
-        String sourceEntry  = options.optString("source");
-        String targetPath   = options.optString("target");
-        
-        if(targetPath.isEmpty()){
-            targetPath      = sourceEntry.substring(0, sourceEntry.lastIndexOf("/")+1);
-        }
 
-        sourceEntry         = sourceEntry.replace("file://", "");
-        targetPath          = targetPath.replace("file://", "");
-        String sourcePath   = sourceEntry.substring(0, sourceEntry.lastIndexOf("/")+1);
-        String sourceName   = sourceEntry.replace(sourcePath, "");
-        sourceName          = (sourceName.lastIndexOf(".")==-1)?sourceName:sourceName.substring(0, sourceName.lastIndexOf("."));
-        
-        if(sourceEntry.isEmpty() || targetPath.isEmpty() || sourcePath.isEmpty() || sourceName.isEmpty()){
-            return null;
-        }
-        
-        options.put("sourceEntry", sourceEntry);
-        options.put("sourcePath", sourcePath);
-        options.put("targetPath", targetPath);
-        options.put("sourceName", sourceName);
+    private void unzip(final JSONArray args, final CallbackContext callbackContext) {
+        try {
+            final String zipPath = Uri.parse(args.getString(0)).getPath();
+            final String targetPath = Uri.parse(args.getString(1)).getPath();
 
-        return options;
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                    try {
+                        new DecompressZip(zipPath).unzip(targetPath);
+                    } catch (Exception e) {
+                        Log.e(TAG, "Unhandled exception decompressing files: " + e);
+                        callbackContext.error(e.getMessage());
+                    }
+                    callbackContext.success();
+                }
+            });
+        } catch (Exception e) {
+            Log.e(TAG, "Unhandled exception parsing parameters: " + e);
+            callbackContext.error(e.getMessage());
+        }
     }
 }

--- a/src/android/compressZip.java
+++ b/src/android/compressZip.java
@@ -5,10 +5,13 @@
  */
 package com.jjdltc.cordova.plugin.zip;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.StringJoiner;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -16,89 +19,68 @@ import org.json.JSONObject;
 
 import android.util.Log;
 
-public class compressZip {
-	
-	private String sourceEntry 	= "";
-	private String targetPath 	= "";
-	private String sourcePath 	= "";
-	private String sourceName 	= "";
-	private String targetName 	= "";
-    private final int BUFFER_SIZE = 2048;
-    
-	public compressZip(JSONObject options) {
-		this.sourceEntry 	= options.optString("sourceEntry");
-		this.targetPath 	= options.optString("targetPath");
-		this.sourcePath 	= options.optString("sourcePath");
-		this.sourceName 	= options.optString("sourceName");
-		this.targetName 	= (options.optString("name").isEmpty())?this.sourceName:options.optString("name");
+import androidx.annotation.Nullable;
+
+public class CompressZip implements Closeable {
+	private static final String TAG = "JJZip:CompressZip";
+	private static final int BUFFER_SIZE = 2048;
+
+	private final ZipOutputStream output;
+	private final byte[] buffer = new byte[BUFFER_SIZE];
+
+	public CompressZip(final String targetPath) throws FileNotFoundException {
+		output = new ZipOutputStream(new FileOutputStream(targetPath));
 	}
-	
-	/**
-	 * Public access to the main class function
-	 * @return 	true if none exception occurs
-	 */
-	public boolean zip() {
-		try {
-			this.makeZip(targetPath+this.targetName+".zip", this.sourceEntry);
-			return true;
-		} catch (Exception e) {
-			e.printStackTrace();
+
+	public void addDir(File dirObj) throws IOException {
+		addDir(dirObj, null);
+	}
+
+	public void addDir(File dirObj, @Nullable final String relativePath) throws IOException {
+		String zipDirPath = dirObj.getName();
+		if (relativePath != null) {
+			zipDirPath = relativePath + File.pathSeparator + zipDirPath;
 		}
-		return false;
-	}
 
-	private void makeZip(String zipFileName, String dir) throws Exception {
-	    File dirObj 		= new File(dir);
-	    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipFileName));
-	    Log.d("JJDLTC Test Log", "Making Zip : " + zipFileName);
-	    if(dirObj.isDirectory()){
-		    this.addDir(dirObj, out);
-	    }
-	    else{
-	    	this.addFile(dirObj, out);
-	    }
-	    out.close();
-    }
-
-	/**
-	 * A convenient method to add the elements in a folder, just call the file zip function when is needit
-	 * @param dirObj		Path to folder (In file object)
-	 * @param out 			Output stream in construction
-	 * @throws IOException
-	 */
-	private void addDir(File dirObj, ZipOutputStream out) throws IOException {
 		File[] files = dirObj.listFiles();
+		if (files == null) {
+			throw new IOException("Could not get files from path: " + dirObj.getAbsolutePath());
+		}
 
-	    for (int i = 0; i < files.length; i++) {
-	    	if (files[i].isDirectory()) {
-		        addDir(files[i], out);
-		        continue;
-	    	}
-	    	else{
-	    		this.addFile(files[i], out);
-	    	}
-	    }
+		for (File file : files) {
+			if (file.isDirectory()) {
+				addDir(file, zipDirPath);
+			} else {
+				addFile(file, zipDirPath);
+			}
+		}
 	}
-	
-	/**
-	 * Add the file to the zip archive
-	 * @param dirObj		Path to file (In file object)
-	 * @param out 			Output stream in construction
-	 * @throws IOException
-	 */	
-	private void addFile(File toZip, ZipOutputStream out) throws IOException{
-		byte[] tmpBuf = new byte[this.BUFFER_SIZE];
-		
-    	FileInputStream in = new FileInputStream(toZip.getAbsolutePath());
-    	Log.d("JJDLTC Test Log "," Adding To Archive: " + toZip.getAbsolutePath());
-    	String zipEntryPath = toZip.getAbsolutePath().replace(this.sourcePath, "");
-    	out.putNextEntry(new ZipEntry(zipEntryPath));
-    	int len;
-    	while ((len = in.read(tmpBuf)) > 0) {
-    		out.write(tmpBuf, 0, len);
-    	}
-    	out.closeEntry();
-    	in.close();		
+
+	public void addFile(File toZip) throws IOException {
+		addFile(toZip, null);
+	}
+
+	public void addFile(File toZip, @Nullable final String relativePath) throws IOException {
+    	Log.d(TAG," Adding To Archive: " + toZip.getAbsolutePath());
+
+		String zipEntryPath = toZip.getName();
+		if (relativePath != null) {
+			zipEntryPath = relativePath + File.pathSeparator + zipEntryPath;
+		}
+
+		try (final FileInputStream in = new FileInputStream(toZip.getAbsolutePath())) {
+			output.putNextEntry(new ZipEntry(zipEntryPath));
+			int len;
+			while ((len = in.read(buffer)) > 0) {
+				output.write(buffer, 0, len);
+			}
+			output.closeEntry();
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		output.close();
 	}
 }
 

--- a/src/ios/JJzip.h
+++ b/src/ios/JJzip.h
@@ -8,7 +8,9 @@
 
 @interface JJzip : CDVPlugin
 
-- (void)zip:(CDVInvokedUrlCommand*)command;
+- (void)zipFolder:(CDVInvokedUrlCommand*)command;
+
+- (void)zipFiles:(CDVInvokedUrlCommand*)command;
 
 - (void)unzip:(CDVInvokedUrlCommand*)command;
 

--- a/www/JJzip.js
+++ b/www/JJzip.js
@@ -4,40 +4,23 @@
  * See a full copy of license in the root folder of the project
  */
 
-var argscheck       = require('cordova/argscheck'),
-    exec            = require('cordova/exec');
+var argscheck = require('cordova/argscheck'),
+    exec = require('cordova/exec');
 
 function JJzip() { }
 
-/**
- *
- * @param {String} Path to the file or directory to zip
- * @param {String} Object with options of the action like
- * {
- *      target  : "Path/to/place/result/file"
- *      , name  : if set, put the result this name, otherwise put the source file name  
- * }
- * @param {Function} successCallback The function to call when the heading data is available
- * @param {Function} errorCallback The function to call when there is an error getting the heading data. (OPTIONAL)
- */
-JJzip.prototype.zip = function(file, options, successCallback, errorCallback) {
-    argscheck.checkArgs('sOFF', 'JJzip.zip', arguments);
-    exec(successCallback, errorCallback, "JJzip", "zip", [file, options]);
+JJzip.prototype.zipFiles = function (file, options, successCallback, errorCallback) {
+    argscheck.checkArgs('ASFF', 'JJzip.zip', arguments);
+    exec(successCallback, errorCallback, "JJzip", "zipFiles", [file, options]);
 };
 
-/**
- *
- * @param {String} Path to the zip file
- * @param {String} Object with options of the action like
- * {
- *      target  : "Path/to/place/result/file"
- *      , name  : if set, put the result this name, otherwise put the source file name  
- * }
- * @param {Function} successCallback The function to call when the heading data is available
- * @param {Function} errorCallback The function to call when there is an error getting the heading data. (OPTIONAL)
- */
-JJzip.prototype.unzip = function(file, options, successCallback, errorCallback) {
-    argscheck.checkArgs('sOFF', 'JJzip.unzip', arguments);
+JJzip.prototype.zipFolder = function (file, options, successCallback, errorCallback) {
+    argscheck.checkArgs('SSFF', 'JJzip.zip', arguments);
+    exec(successCallback, errorCallback, "JJzip", "zipFolder", [file, options]);
+};
+
+JJzip.prototype.unzip = function (file, options, successCallback, errorCallback) {
+    argscheck.checkArgs('SSFF', 'JJzip.unzip', arguments);
     exec(successCallback, errorCallback, "JJzip", "unzip", [file, options]);
 };
 

--- a/www/JJzip.js
+++ b/www/JJzip.js
@@ -9,19 +9,19 @@ var argscheck = require('cordova/argscheck'),
 
 function JJzip() { }
 
-JJzip.prototype.zipFiles = function (file, options, successCallback, errorCallback) {
+JJzip.prototype.zipFiles = function (files, destination, successCallback, errorCallback) {
     argscheck.checkArgs('ASFF', 'JJzip.zip', arguments);
-    exec(successCallback, errorCallback, "JJzip", "zipFiles", [file, options]);
+    exec(successCallback, errorCallback, "JJzip", "zipFiles", [files, destination]);
 };
 
-JJzip.prototype.zipFolder = function (file, options, successCallback, errorCallback) {
+JJzip.prototype.zipFolder = function (folder, destination, successCallback, errorCallback) {
     argscheck.checkArgs('SSFF', 'JJzip.zip', arguments);
-    exec(successCallback, errorCallback, "JJzip", "zipFolder", [file, options]);
+    exec(successCallback, errorCallback, "JJzip", "zipFolder", [folder, destination]);
 };
 
-JJzip.prototype.unzip = function (file, options, successCallback, errorCallback) {
+JJzip.prototype.unzip = function (file, destination, successCallback, errorCallback) {
     argscheck.checkArgs('SSFF', 'JJzip.unzip', arguments);
-    exec(successCallback, errorCallback, "JJzip", "unzip", [file, options]);
+    exec(successCallback, errorCallback, "JJzip", "unzip", [file, destination]);
 };
 
 module.exports = new JJzip();


### PR DESCRIPTION
Adding the following functionality to the plugin:

* Support for creating ZIP files in IOS
* Support for creating ZIP files from multiple input source files
* Running plugin logic asynchronously

This makes breaking changes to the API (see further below for examples):

* `zip` method removed
* New `zipFolder` method to create ZIP from single folder (similar to previous `zip` method)
  * Removed `options` parameter, replaced with parameter containing target zip file
* New `zipFiles` method to create ZIP from one or more files
* Removed `options` parameter from `unzip` method, replaced with parameter containing target folder

Examples:

```
// Creating ZIP from single folder
window.JJzip.zipFolder(
    cordova.file.dataDirectory + 'inputFolder',
    cordova.file.dataDirectory + 'out.zip',
    function() { console.log('success'); },
    function(err) { console.log('error: ' + err) });
```
```
// Creating ZIP with multiple files
const files = [
    cordova.file.dataDirectory + 'file1.txt',
    cordova.file.dataDirectory + 'file2.txt',
];
window.JJzip.zipFiles(
    files,
    cordova.file.dataDirectory + 'out.zip',
    function() { console.log('success'); },
    function(err) { console.log('error: ' + err) });
```
```
// Unzipping into target folder
window.JJzip.unzip(
    cordova.file.dataDirectory + 'input.zip',
    cordova.file.dataDirectory + 'extracted',
    function() { console.log('success'); },
    function(err) { console.log('error: ' + err) });
```