### PR TITLE
Removed version of SSZipArchive to make it build with current version of ios

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -50,7 +50,7 @@ See a full copy of license in the root folder of the project
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="SSZipArchive" spec="~> 2.1.4" />
+                <pod name="SSZipArchive" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
We wanted to use this plugin on a Cordova project, but it was not building with current version of the ios platform.

I'm not sure 100% of the cause, but I think this is due to the fact that the plugin is using an old version of SSZipArchive that is not compatible with current version of Xcode.

Removing the SSZipArchive version number, it works.

I'm not sure if it's better to specify another version of SSZipArchive, but this worked for me and I'm happy with that.
